### PR TITLE
Fix Vite sourcemap warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,12 +54,7 @@ export default function VitePluginInlineSource(
   async function transformHtml(
     source: string,
     ctx: TransformPluginContext | IndexHtmlTransformContext,
-    id?: string
   ) {
-    if (id && !id.endsWith(".html")) {
-      return source;
-    }
-
     const result = [];
     const tokens = source.matchAll(PATTERN);
     let prevPos = 0;
@@ -144,7 +139,11 @@ export default function VitePluginInlineSource(
       root = config.root ?? "";
     },
     transform(source, id) {
-      return transformHtml(source, this, id);
+      if (id && !id.endsWith(".html")) {
+        return null;
+      }
+
+      return transformHtml(source, this);
     },
     transformIndexHtml(source, ctx) {
       return transformHtml(source, ctx);


### PR DESCRIPTION
Hi there! I have a large codebase and here's the warning I've got for every asset so the build:
```
(vite-plugin-inline-source plugin) Sourcemap is likely to be incorrect: a plugin (vite-plugin-inline-source) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```

This is my attempt to fix this behavior.