### PR TITLE
Fix Vite deprecated sass import warning

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -123,9 +123,7 @@ test("fails gracefully when svg optimization fails", () => {
         inlineSource({}),
       ],
     });
-  }).rejects.toThrowErrorMatchingInlineSnapshot(
-    '"<input>:1:35: Attribute without value"'
-  );
+  }).rejects.toThrowError('Attribute without value');
 });
 
 test("it then optimizes svg with custom options", async () => {
@@ -227,7 +225,7 @@ describe("css", () => {
           }),
         ],
       });
-    }).rejects.toThrowErrorMatchingInlineSnapshot('"Failed to minify CSS"');
+    }).rejects.toThrowError('Failed to minify CSS');
   });
 
   test("fails gracefully when css minification fails", () => {
@@ -244,7 +242,7 @@ describe("css", () => {
           }),
         ],
       });
-    }).rejects.toThrowErrorMatchingInlineSnapshot('"Failed to minify CSS"');
+    }).rejects.toThrowError('Failed to minify CSS');
   });
 });
 
@@ -391,7 +389,10 @@ describe("js", () => {
         ],
       });
     }).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"Unexpected token: name (a)"'
+      `
+      "[31m[vite-plugin-inline-source] Unexpected token: name (a)[39m
+      file: [36m/Users/stryaponov/Documents/Projects/_3rd-party/vite-plugin-inline-source/src/__tests__/index.html[39m"
+    `
     );
   });
 });

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -388,12 +388,7 @@ describe("js", () => {
           }),
         ],
       });
-    }).rejects.toThrowErrorMatchingInlineSnapshot(
-      `
-      "[31m[vite-plugin-inline-source] Unexpected token: name (a)[39m
-      file: [36m/Users/stryaponov/Documents/Projects/_3rd-party/vite-plugin-inline-source/src/__tests__/index.html[39m"
-    `
-    );
+    }).rejects.toThrowError('Unexpected token: name (a)');
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import type { IndexHtmlTransformContext, Plugin } from "vite";
 import { optimize as optimizeSvg } from "svgo";
 import { minify as minifyCss } from "csso";
 import { minify as minifyJs } from "terser";
-import sass from "sass";
+import * as sass from "sass";
 import type { TransformPluginContext } from "rollup";
 import z from "zod";
 const { compileString: compileSass } = sass;


### PR DESCRIPTION
This fixes the following Vite warning:
```
`import sass from 'sass'` is deprecated.
Please use `import * as sass from 'sass'` instead.
```

This also fixes the broken tests